### PR TITLE
Cors cm

### DIFF
--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -11,6 +11,7 @@ using BangazonApi.Models;
 namespace BangazonApi.Controllers
 {
     [Route("api/[controller]")]
+    
     public class OrdersController : Controller
     {
         private ApplicationDbContext _context;

--- a/Startup.cs
+++ b/Startup.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using BangazonApi.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Cors.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,6 +27,12 @@ namespace BangazonApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddCors(options =>
+            {
+                options.AddPolicy("AllowSpecificOrigin",
+                    builder => builder.WithOrigins("http://bangazon.com:5000"));
+            });
+            
             services.AddMvc();
 
             var path = System.Environment.GetEnvironmentVariable("BANGAZON");
@@ -39,6 +47,8 @@ namespace BangazonApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.UseCors("AllowSpecificOrigin");
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/Startup.cs
+++ b/Startup.cs
@@ -30,7 +30,7 @@ namespace BangazonApi
             services.AddCors(options =>
             {
                 options.AddPolicy("AllowSpecificOrigin",
-                    builder => builder.WithOrigins("http://bangazon.com:5000"));
+                    builder => builder.WithOrigins("http://bangazon.com:8080", "http://bangazon.com:5000"));
             });
             
             services.AddMvc();


### PR DESCRIPTION
## Ticket Link:
  - #12 

## Description:
  - Added CORS policy to only allow cross origin access to api through bangazon.com:8080 and bangazon.com:500

## Steps to Test:

#### SETUP
1. git fetch 
1. git checkout cors-cm
1. Download BangazonApiTest project - zip file included in comment

#### Alias localhost into bangazon.com
1. Run ```sudo nano /etc/hosts``` in terminal to open hosts file
1. Enter your password
1. add 127.0.0.1 and bangazon.com to the last line of ip addresses
1. press ^o (control + o) to save
1. press enter to overwrite file location
1. press ^x (control + x) to exit

#### Seed Data into database
1.  From the BangazonApi directory in terminal run ```dotnet run```
1.  Using the rest client of your choice add multiple customers into the database

#### Test CORS Policy
1. With the API still running start a http server for the BangazonApiTest project (this is a blank project that loads jQuery) - make sure the server is on the default port of http://127.0.0.1:8080
1. In the dev tools console execute this xhr request below, this should result in the error :
'Failed to load http://localhost:5000/api/customer: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://127.0.0.1:8080' is therefore not allowed access.'
```
$.ajax({
  url: "http://localhost:5000/api/customer",
  context: document.body
}).then()
```
3. Confirm that the request return no results in the dev tools network tab
4. Change http://127.0.0.1:8080 to http://bangazon.com:8080/ in your navigation bar and load the page, the same blank project should be loaded
5. ReExecute the above xhr request - this should result in NO errors
6. Confirm that a JSON was returned via the Network tab and that the data you seeded is included